### PR TITLE
Feature/player death counter backend

### DIFF
--- a/docs/api/player.md
+++ b/docs/api/player.md
@@ -58,7 +58,8 @@
               y: 0
             }, 
             dimensions: 30,
-            nickname: 'unnamed'
+            nickname: 'unnamed',
+            deaths: 0
         },
         // ...
     ] 
@@ -94,7 +95,8 @@
 ```
 { 
   Player: { 
-    id: 1 
+    id: 1,
+    deaths: 0
   },
   Damage: 10,
   Damager: {
@@ -113,7 +115,8 @@
 ```
 { 
   Player: { 
-    id: 1 
+    id: 1,
+    deaths: 0
   },
   // Новая позиция игрока
   Vector: { 

--- a/docs/api/player.md
+++ b/docs/api/player.md
@@ -41,7 +41,7 @@
 ```
 
 ## Players
-Выдает список игркоов.
+Выдает список игроков.
 
 **Имя события**: `players`
 
@@ -59,7 +59,8 @@
             }, 
             dimensions: 30,
             nickname: 'unnamed',
-            deaths: 0
+            deaths: 0,
+            kills: 0
         },
         // ...
     ] 
@@ -87,6 +88,8 @@
 ```
 
 ## PlayerDied
+NOTE: В поле Damager.kills прийдёт новое кол-во убийств убийцы или -1, если убийца не игрок (Damager.entityClass соответственно будет не 'player').
+
 **Имя события**: `playerDied`
 
 **Broadcast**: `+`
@@ -101,7 +104,8 @@
   Damage: 10,
   Damager: {
     id: 1,
-    entityClass: entity
+    entityClass: entity,
+    kills: 1
   }
 }
 ```
@@ -116,7 +120,8 @@
 { 
   Player: { 
     id: 1,
-    deaths: 0
+    deaths: 0,
+    kills: 0
   },
   // Новая позиция игрока
   Vector: { 

--- a/server/core/damage-spell.js
+++ b/server/core/damage-spell.js
@@ -22,6 +22,6 @@ module.exports = class DamageSpell extends Missile {
      * @param {Entity} damagedEntity - сущность, которой будет нанесён урон
      */
     hurt(damagedEntity) {
-        damagedEntity.onDamaged(this, DAMAGE);
+        damagedEntity.onDamaged(this.creator, DAMAGE);
     }
 }

--- a/server/core/entity.js
+++ b/server/core/entity.js
@@ -180,6 +180,7 @@ module.exports = class Entity {
      */
     onDeath(killer) {
         this.__isDead = true;
+        killer.iKilled(this);
     }
 
     /**
@@ -190,5 +191,14 @@ module.exports = class Entity {
         this.__health = this.maxHealth;
         this.randomPosition();
         this.__isDead = false;
+    }
+
+    /**
+     * Действия при убийстве другой сущности
+     * 
+     * @param {Entity} prey - жертва, сущность, которая была убита этой сущностью
+     */
+    iKilled(prey) {
+
     }
 };

--- a/server/core/missile.js
+++ b/server/core/missile.js
@@ -68,6 +68,15 @@ module.exports = class Missile extends Entity {
     }
 
     /**
+     * Действия при убийстве другой сущности
+     * 
+     * @param {Entity} prey - жертва, сущность, которая была убита этой сущностью
+     */
+    iKilled(prey) {
+        this.creator.iKilled(prey);
+    }
+
+    /**
      * Действия при смерти сущности
      *
      * @param {Entity} killer

--- a/server/entities/player.js
+++ b/server/entities/player.js
@@ -24,6 +24,7 @@ module.exports = class Player extends Entity {
         this.__health = PLAYER_START_HEALTH;
         this.speed = PLAYER_MOVE_SPEED;
         this.__nickname = nick;
+        this.__countOfDeaths = 0;
 
         (new PlayerMessages.Connected())
             .withPlayer(this)
@@ -83,6 +84,8 @@ module.exports = class Player extends Entity {
     onDeath(killer, damage) {
         super.onDeath(killer);
 
+        this.__countOfDeaths++;
+
         this.__reSpawnTimeout = setTimeout(() => {
             this.reSpawn();
         }, PLAYER_RESPAWN_TIME * 1000);
@@ -119,5 +122,9 @@ module.exports = class Player extends Entity {
 
     get nickname() {
         return this.__nickname;
+    }
+
+    get countOfDeaths() {
+        return this.__numberOfDeaths;
     }
 };

--- a/server/entities/player.js
+++ b/server/entities/player.js
@@ -137,10 +137,10 @@ module.exports = class Player extends Entity {
     }
 
     get countOfDeaths() {
-        return this.__numberOfDeaths;
+        return this.__countOfDeaths;
     }
 
-    get countOfkills() {
+    get countOfKills() {
         return this.__countOfkills;
     }
 };

--- a/server/entities/player.js
+++ b/server/entities/player.js
@@ -25,6 +25,7 @@ module.exports = class Player extends Entity {
         this.speed = PLAYER_MOVE_SPEED;
         this.__nickname = nick;
         this.__countOfDeaths = 0;
+        this.__countOfkills = 0;
 
         (new PlayerMessages.Connected())
             .withPlayer(this)
@@ -114,9 +115,20 @@ module.exports = class Player extends Entity {
      * @param {Entity} collidedWithEntity - Сущность, с которой произошло столкновение
      */
     onCollide(collidedWithEntity) {
-        // переписать этот говнокод
+        // переписать
         if (!(collidedWithEntity instanceof Player)) {
             collidedWithEntity.onCollide(this);
+        }
+    }
+
+    /**
+     * Действия при убийстве другой сущности
+     * 
+     * @param {Entity} prey - жертва, сущность, которая была убита этой сущностью
+     */
+    iKilled(prey) {
+        if(prey instanceof Player) {
+            this.__countOfkills++;
         }
     }
 
@@ -126,5 +138,9 @@ module.exports = class Player extends Entity {
 
     get countOfDeaths() {
         return this.__numberOfDeaths;
+    }
+
+    get countOfkills() {
+        return this.__countOfkills;
     }
 };

--- a/server/messages/player.js
+++ b/server/messages/player.js
@@ -54,6 +54,14 @@ module.exports = {
 
             return this;
         }
+
+        withDamage(damage, damager) {
+            super.withDamage(damage, damager);
+
+            this.DTO.Damager.kills = damager.countOfKills || -1;
+
+            return this;
+        }
     },
 
     Respawn: class ReSpawnMessage extends Message {
@@ -66,6 +74,7 @@ module.exports = {
 
             super.DTO.Player.nickname = player.nickname;
             this.DTO.Player.deaths = player.countOfDeaths;
+            this.DTO.Player.kills = player.countOfKills;
 
             return this;
         }
@@ -96,7 +105,8 @@ module.exports = {
                     },
                     dimensions: player.dimensions,
                     nickname: player.nickname,
-                    deaths: player.countOfDeaths
+                    deaths: player.countOfDeaths,
+                    kills: player.countOfKills
                 });
             });
         }

--- a/server/messages/player.js
+++ b/server/messages/player.js
@@ -46,6 +46,14 @@ module.exports = {
         constructor() {
             super('playerDied');
         }
+
+        withPlayer(player) {
+            super.withPlayer(player);
+
+            this.DTO.Player.deaths = player.countOfDeaths;
+
+            return this;
+        }
     },
 
     Respawn: class ReSpawnMessage extends Message {
@@ -57,6 +65,7 @@ module.exports = {
             super.withPlayer(player);
 
             super.DTO.Player.nickname = player.nickname;
+            this.DTO.Player.deaths = player.countOfDeaths;
 
             return this;
         }
@@ -86,7 +95,8 @@ module.exports = {
                         y: player.y
                     },
                     dimensions: player.dimensions,
-                    nickname: player.nickname
+                    nickname: player.nickname,
+                    deaths: player.countOfDeaths
                 });
             });
         }


### PR DESCRIPTION
#57 
Добавил подсчёт количества смертей у игроков.
Количество передаётся в трёх сообщениях: _players_, _playerDied_ и _playerRespawn_.

UPD #70 
Добавил подсчёт фрагов для игроков.
Обновлены теже сообщения. Фронтъэндерам рекомендуется заглянуть в readme.